### PR TITLE
Add `matchesWon` to `Stats` type

### DIFF
--- a/functions/src/helpers/firebase.helpers.ts
+++ b/functions/src/helpers/firebase.helpers.ts
@@ -120,36 +120,37 @@ export const getLeader = async (
     .withConverter(playerConverter)
     .get();
 
-  const [firstPlace, secondPlace] = playerSnap.docs;
+  const [firstPlaceSnap, secondPlaceSnap] = playerSnap.docs;
+
+  const firstPlace = firstPlaceSnap.data();
+  const secondPlace = secondPlaceSnap.data();
 
   const isFoosball = sport === Sport.Foosball;
   const isTableTennis = sport === Sport.TableTennis;
 
   if (isFoosball) {
-    const winnerHasPlayedAtLeastOnce =
-      firstPlace.data().foosballStats?.score != null;
+    const winnerHasPlayedAtLeastOnce = firstPlace.foosballStats?.score != null;
 
     const moreThanOneWinner =
-      firstPlace.data().foosballStats?.score ===
-      secondPlace.data().foosballStats?.score;
+      firstPlace.foosballStats?.score === secondPlace.foosballStats?.score;
 
     if (!winnerHasPlayedAtLeastOnce || moreThanOneWinner) {
       return null;
     }
   } else if (isTableTennis) {
     const winnerHasPlayedAtLeastOnce =
-      firstPlace.data().tableTennisStats?.score != null;
+      firstPlace.tableTennisStats?.score != null;
 
     const moreThanOneWinner =
-      firstPlace.data().tableTennisStats?.score ===
-      secondPlace.data().tableTennisStats?.score;
+      firstPlace.tableTennisStats?.score ===
+      secondPlace.tableTennisStats?.score;
 
     if (!winnerHasPlayedAtLeastOnce || moreThanOneWinner) {
       return null;
     }
   }
 
-  return firstPlace.data();
+  return firstPlace;
 };
 
 export const incrementTotalSeasonWins = async (
@@ -184,11 +185,13 @@ export const resetScoreboards = async (initialScore: number): Promise<void> => {
     if (player.foosballStats) {
       player.foosballStats.score = initialScore;
       player.foosballStats.matchesPlayed = 0;
+      player.foosballStats.matchesWon = 0;
     }
 
     if (player.tableTennisStats) {
       player.tableTennisStats.score = initialScore;
       player.tableTennisStats.matchesPlayed = 0;
+      player.tableTennisStats.matchesWon = 0;
     }
 
     await updatePlayer(player);

--- a/functions/src/helpers/sport.helpers.ts
+++ b/functions/src/helpers/sport.helpers.ts
@@ -5,6 +5,7 @@ import { Stats } from "../types/Stats";
 
 export const getEmptyStats = (sport: Sport): Stats => ({
   matchesPlayed: 0,
+  matchesWon: 0,
   score: initialScore,
   sport,
   seasonWins: 0,

--- a/functions/src/types/Stats.ts
+++ b/functions/src/types/Stats.ts
@@ -4,5 +4,6 @@ export type Stats = {
   sport: Sport;
   score: number;
   matchesPlayed: number;
+  matchesWon: number;
   seasonWins: number;
 };


### PR DESCRIPTION
Resolves #44

⚠️   This branch has already been deployed and is (per Sep 3 09:00) the current live version.

- [x] `matchesWon` is reset for every sport when the scoreboard is reset.
- [x] `matchesWon`'s initial value is 0.
- [x] The winner's `matchesWon` value of the played sport is increased by 1 for every win.