### PR TITLE
refactor: split firebase helpers into separate files

### DIFF
--- a/Firebase/functions/src/firebase/match.ts
+++ b/Firebase/functions/src/firebase/match.ts
@@ -1,0 +1,25 @@
+import * as admin from "firebase-admin";
+import { getCollection } from "../helpers/firebase.helpers";
+import { Match } from "../types/Match";
+
+const getMatchCollection = () => getCollection<Match>("matches");
+
+const matchConverter: admin.firestore.FirestoreDataConverter<Match> = {
+  fromFirestore: snapshot => {
+    const match: Match = {
+      date: snapshot.get("date"),
+      loser: snapshot.get("loser"),
+      loserDelta: snapshot.get("loserDelta"),
+      sport: snapshot.get("sport"),
+      winner: snapshot.get("winner"),
+      winnerDelta: snapshot.get("winnerDelta"),
+    };
+
+    return match;
+  },
+  toFirestore: match => match,
+};
+
+export const addMatch = async (match: Match): Promise<void> => {
+  await getMatchCollection().withConverter(matchConverter).add(match);
+};

--- a/Firebase/functions/src/firebase/player.ts
+++ b/Firebase/functions/src/firebase/player.ts
@@ -1,0 +1,82 @@
+import * as admin from "firebase-admin";
+import { getCollection } from "../helpers/firebase.helpers";
+import { getEmptyStats } from "../helpers/sport.helpers";
+import { Player } from "../types/Player";
+import { Sport } from "../types/Sport";
+
+const getPlayerCollection = () => getCollection<Player>("players");
+
+const playerConverter: admin.firestore.FirestoreDataConverter<Player> = {
+  fromFirestore: snapshot => {
+    const player: Player = {
+      userId: snapshot.id,
+      emoji: snapshot.get("emoji"),
+      nickname: snapshot.get("nickname"),
+      foosballStats: snapshot.get("foosballStats"),
+      poolStats: snapshot.get("poolStats"),
+      tableTennisStats: snapshot.get("tableTennisStats"),
+      team: snapshot.get("team"),
+      teamId: snapshot.get("teamId") ?? snapshot.get("team").id,
+      stats: snapshot.get("stats") ?? [snapshot.get("foosballStats")],
+    };
+
+    return player;
+  },
+  toFirestore: player => ({
+    emoji: player.emoji,
+    nickname: player.nickname,
+    foosballStats: player.foosballStats,
+    poolStats: player.poolStats,
+    tableTennisStats: player.tableTennisStats,
+    team: player.team,
+    // @ts-expect-error `player.team` is a Team (or undefined)
+    teamId: player.teamId ?? player.team?.id,
+  }),
+};
+
+export const getPlayer = async (id: string): Promise<Player | undefined> => {
+  const playerSnap = await getPlayerCollection()
+    .withConverter(playerConverter)
+    .doc(id)
+    .get();
+
+  const player = playerSnap.data();
+  return player;
+};
+
+export const getPlayers = async (teamId?: string): Promise<Array<Player>> => {
+  const collection = getPlayerCollection();
+  let query: admin.firestore.Query<Player>;
+
+  if (teamId) {
+    query = collection.where("team.id", "==", teamId);
+  } else {
+    query = collection;
+  }
+
+  const snapshots = (await query.withConverter(playerConverter).get()).docs;
+  return snapshots.map(snapshot => snapshot.data());
+};
+
+export const updatePlayer = async (player: Player): Promise<void> => {
+  const updatedPlayer: Omit<Player, "userId"> = {
+    emoji: player.emoji,
+    nickname: player.nickname,
+    foosballStats: player.foosballStats ?? getEmptyStats(Sport.Foosball),
+    tableTennisStats:
+      player.tableTennisStats ?? getEmptyStats(Sport.TableTennis),
+    poolStats: player.poolStats ?? getEmptyStats(Sport.Pool),
+    stats: player.stats ?? [
+      player.foosballStats ?? getEmptyStats(Sport.Foosball),
+      player.tableTennisStats ?? getEmptyStats(Sport.TableTennis),
+      player.poolStats ?? getEmptyStats(Sport.Pool),
+    ],
+    team: player.team,
+    teamId: player.teamId ?? player.team.id ?? undefined,
+  };
+
+  await getPlayerCollection()
+    .withConverter(playerConverter)
+    .doc(player.userId)
+    .update(updatedPlayer);
+};

--- a/Firebase/functions/src/firebase/season.ts
+++ b/Firebase/functions/src/firebase/season.ts
@@ -1,0 +1,30 @@
+import * as admin from "firebase-admin";
+import { getCollection } from "../helpers/firebase.helpers";
+import { Player } from "../types/Player";
+import { Season } from "../types/Season";
+import { Sport } from "../types/Sport";
+
+const getSeasonCollection = () => getCollection<Season>("seasons");
+
+const seasonConverter: admin.firestore.FirestoreDataConverter<Season> = {
+  fromFirestore: snapshot => {
+    const season: Season = {
+      date: snapshot.get("date"),
+      sport: snapshot.get("sport"),
+      winner: snapshot.get("winner"),
+    };
+
+    return season;
+  },
+  toFirestore: season => season,
+};
+
+export const storeSeason = async (
+  winner: Player,
+  sport: Sport,
+  date: admin.firestore.Timestamp,
+): Promise<void> => {
+  await getSeasonCollection()
+    .withConverter(seasonConverter)
+    .add({ winner, sport, date });
+};

--- a/Firebase/functions/src/helpers/firebase.helpers.ts
+++ b/Firebase/functions/src/helpers/firebase.helpers.ts
@@ -1,142 +1,31 @@
 import * as admin from "firebase-admin";
-import { Match } from "../types/Match";
+import { getPlayers, updatePlayer } from "../firebase/player";
 import type { Player } from "../types/Player";
-import { Season } from "../types/Season";
 import { Sport } from "../types/Sport";
-import { getEmptyStats, getSportScore, getSportStats } from "./sport.helpers";
+import { getSportScore, getSportStats } from "./sport.helpers";
 
 admin.initializeApp({
   storageBucket: "officesports-5d7ac.appspot.com",
 });
 admin.firestore().settings({ ignoreUndefinedProperties: true });
 
-const getCollection = <Type = admin.firestore.DocumentData>(
+export const getCollection = <Type = admin.firestore.DocumentData>(
   collectionName: string,
 ): admin.firestore.CollectionReference<Type> =>
   admin
     .firestore()
     .collection(collectionName) as admin.firestore.CollectionReference<Type>;
 
-const getPlayerCollection = () => getCollection<Player>("players");
-const getMatchCollection = () => getCollection<Match>("matches");
-const getSeasonCollection = () => getCollection<Season>("seasons");
-
-const playerConverter: admin.firestore.FirestoreDataConverter<Player> = {
-  fromFirestore: snapshot => {
-    const player: Player = {
-      userId: snapshot.id,
-      emoji: snapshot.get("emoji"),
-      nickname: snapshot.get("nickname"),
-      foosballStats: snapshot.get("foosballStats"),
-      poolStats: snapshot.get("poolStats"),
-      tableTennisStats: snapshot.get("tableTennisStats"),
-      team: snapshot.get("team"),
-      teamId: snapshot.get("teamId") ?? snapshot.get("team").id,
-      stats: snapshot.get("stats") ?? [snapshot.get("foosballStats")],
-    };
-
-    return player;
-  },
-  toFirestore: player => ({
-    emoji: player.emoji,
-    nickname: player.nickname,
-    foosballStats: player.foosballStats,
-    poolStats: player.poolStats,
-    tableTennisStats: player.tableTennisStats,
-    team: player.team,
-    // @ts-expect-error `player.team` is a Team (or undefined)
-    teamId: player.teamId ?? player.team?.id,
-  }),
-};
-
-const matchConverter: admin.firestore.FirestoreDataConverter<Match> = {
-  fromFirestore: snapshot => {
-    const match: Match = {
-      date: snapshot.get("date"),
-      loser: snapshot.get("loser"),
-      loserDelta: snapshot.get("loserDelta"),
-      sport: snapshot.get("sport"),
-      winner: snapshot.get("winner"),
-      winnerDelta: snapshot.get("winnerDelta"),
-    };
-
-    return match;
-  },
-  toFirestore: match => match,
-};
-
-const seasonConverter: admin.firestore.FirestoreDataConverter<Season> = {
-  fromFirestore: snapshot => {
-    const season: Season = {
-      date: snapshot.get("date"),
-      sport: snapshot.get("sport"),
-      winner: snapshot.get("winner"),
-    };
-
-    return season;
-  },
-  toFirestore: season => season,
-};
-
-export const getPlayer = async (id: string): Promise<Player | undefined> => {
-  const playerSnap = await getPlayerCollection()
-    .withConverter(playerConverter)
-    .doc(id)
-    .get();
-
-  const player = playerSnap.data();
-  return player;
-};
-
-export const updatePlayer = async (player: Player): Promise<void> => {
-  const updatedPlayer: Omit<Player, "userId"> = {
-    emoji: player.emoji,
-    nickname: player.nickname,
-    foosballStats: player.foosballStats ?? getEmptyStats(Sport.Foosball),
-    tableTennisStats:
-      player.tableTennisStats ?? getEmptyStats(Sport.TableTennis),
-    poolStats: player.poolStats ?? getEmptyStats(Sport.Pool),
-    stats: player.stats ?? [
-      player.foosballStats ?? getEmptyStats(Sport.Foosball),
-      player.tableTennisStats ?? getEmptyStats(Sport.TableTennis),
-      player.poolStats ?? getEmptyStats(Sport.Pool),
-    ],
-    team: player.team,
-    teamId: player.teamId ?? player.team.id ?? undefined,
-  };
-
-  await getPlayerCollection()
-    .withConverter(playerConverter)
-    .doc(player.userId)
-    .update(updatedPlayer);
-};
-
-export const addMatch = async (match: Match): Promise<void> => {
-  await getMatchCollection().withConverter(matchConverter).add(match);
-};
-
 export const getLeader = async (
   sport: Sport,
-  team?: string,
+  teamId?: string,
 ): Promise<Player | null> => {
-  const allPlayers = getPlayerCollection();
-  let playerQuery;
-
-  if (team) {
-    playerQuery = allPlayers.where("team.id", "==", team);
-  } else {
-    playerQuery = allPlayers;
-  }
-
   const getSpecificSportScore = getSportScore(sport);
   const sortBySportScoreDesc = (player1: Player, player2: Player) =>
     getSpecificSportScore(player2) - getSpecificSportScore(player1);
 
-  const playerSnap = await playerQuery.withConverter(playerConverter).get();
-
-  const [firstPlace, secondPlace] = playerSnap.docs
-    .map(playerSnap => playerSnap.data())
-    .sort(sortBySportScoreDesc);
+  const allPlayers = await getPlayers(teamId);
+  const [firstPlace, secondPlace] = allPlayers.sort(sortBySportScoreDesc);
 
   const firstPlaceStats = getSportStats(firstPlace, sport);
   const secondPlaceStats = getSportStats(secondPlace, sport);
@@ -161,15 +50,8 @@ export const incrementTotalSeasonWins = async (
   updatePlayer(player);
 };
 
-export const getAllPlayers = async (): Promise<Array<Player>> => {
-  const playerSnapshots = (
-    await getPlayerCollection().withConverter(playerConverter).get()
-  ).docs;
-  return playerSnapshots.map(player => player.data());
-};
-
 export const resetScoreboards = async (initialScore: number): Promise<void> => {
-  const allPlayers = await getAllPlayers();
+  const allPlayers = await getPlayers();
 
   console.log("All players", allPlayers);
 
@@ -200,14 +82,4 @@ export const resetScoreboards = async (initialScore: number): Promise<void> => {
 
     await updatePlayer(player);
   }
-};
-
-export const storeSeason = async (
-  winner: Player,
-  sport: Sport,
-  date: admin.firestore.Timestamp,
-): Promise<void> => {
-  await getSeasonCollection()
-    .withConverter(seasonConverter)
-    .add({ winner, sport, date });
 };

--- a/Firebase/functions/src/index.ts
+++ b/Firebase/functions/src/index.ts
@@ -3,15 +3,14 @@ import * as firebase from "firebase-admin";
 import * as functions from "firebase-functions";
 import HttpStatus from "http-status-enum";
 import { initialScore, tietoevryCreateTeamId } from "./constants";
+import { addMatch } from "./firebase/match";
+import { getPlayer, updatePlayer } from "./firebase/player";
+import { storeSeason } from "./firebase/season";
 import { sendErrorStatus } from "./helpers/api.helpers";
 import {
-  addMatch,
   getLeader,
-  getPlayer,
   incrementTotalSeasonWins,
   resetScoreboards,
-  storeSeason,
-  updatePlayer,
 } from "./helpers/firebase.helpers";
 import { setEmptyPlayerStats } from "./helpers/player.helpers";
 import * as slackHelpers from "./helpers/slack.helpers";


### PR DESCRIPTION
`firebase.helpers.ts` has grown too big and does too many different things. Let's separate CRUD actions into files per data type. "Molecule" functions that touches multiple repository functions and types are retained within firebase helpers still.

- #61