### PR TITLE
Add console logs when calculating seasonal winners

### DIFF
--- a/Firebase/functions/src/api/resetScoreboardsCron.ts
+++ b/Firebase/functions/src/api/resetScoreboardsCron.ts
@@ -39,12 +39,17 @@ const resetScoreboardsFunction = async () => {
   for (const team of teams) {
     const teamId = team.id;
     if (!teamId) {
+      console.log("TeamId is undefiend");
       continue;
     }
 
     for (const sport of sports) {
+      console.log("Calculating seasonal winner");
       const seasonWinner = await getLeader(sport, teamId);
       if (!seasonWinner) {
+        console.log(
+          `No seasonal winner found for ${team.name}, sport: ${sport}`,
+        );
         continue;
       }
 


### PR DESCRIPTION
More logging was added to the calculation of seasonal winners in cloud function `resetScoreboardsCron`. Related to [Issue 113](https://github.com/oyvinddd/officesports/issues/113).

Changes in this pull request are already deployed to Firebase Functions. 